### PR TITLE
Update GA bridge implementation

### DIFF
--- a/ReactApp/containers/app.js
+++ b/ReactApp/containers/app.js
@@ -29,8 +29,8 @@ import AppConfig from '../config';
 import AppUtil from '../util';
 
 // Google Analytics
-import GoogleAnalytics from 'react-native-google-analytics-bridge';
-GoogleAnalytics.setTrackerId(AppConfig.gaTrackingId);
+import { GoogleAnalyticsTracker } from 'react-native-google-analytics-bridge';
+const tracker = new GoogleAnalyticsTracker(AppConfig.gaTrackingId);
 
 // Components
 import Menu from '../components/menu';
@@ -86,7 +86,7 @@ class AppContainer extends Component {
 
     // Google Analytics
     let screenName = route.component.componentName ? route.component.componentName + ' - ' + title : title;
-    GoogleAnalytics.trackScreenView(screenName);
+    tracker.trackScreenView(screenName);
 
     // Show Hamburger Icon when index is 0, and Back Arrow Icon when index is > 0
     let leftButton = {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "react": "15.3.2",
     "react-addons-shallow-compare": "^15.3.2",
     "react-native": "^0.35.0",
-    "react-native-google-analytics-bridge": "^3.1.0",
+    "react-native-google-analytics-bridge": "^4.0.1",
     "react-native-navbar": "^1.5.4",
     "react-native-side-menu": "^0.20.1",
     "react-native-tab-view": "0.0.29",


### PR DESCRIPTION
Newest version of GA has deprecated the old `setTrackerId`, and rather constructs the class to allow multiple trackers. Would of course for a larger app recommend putting the tracker construction + configuration in its own file, and export that in turn to the rest of the app.