### PR TITLE
Implement Jest tests for Redux and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+[![GitHub tag](https://img.shields.io/github/tag/mcnamee/react-native-starter-app.svg)]()
+[![GitHub contributors](https://img.shields.io/github/contributors/mcnamee/react-native-starter-app.svg)]()
+[![license](https://img.shields.io/github/license/mcnamee/react-native-starter-app.svg)]()
+[![Bitbucket issues](https://img.shields.io/github/issues/mcnamee/react-native-starter-app.svg)]()
+[![GitHub closed issues](https://img.shields.io/github/issues-closed/mcnamee/react-native-starter-app.svg)]()
+[![GitHub pull requests](https://img.shields.io/github/issues-pr/mcnamee/react-native-starter-app.svg)]()
+
 ![alt text](https://dl.dropboxusercontent.com/u/46690444/GITHUB/rnsk-logo.jpg "React Native Starter Kit")
 
 # React Native Starter Kit
@@ -68,6 +75,3 @@ React Native Starter Kit helps you get started with React Native. It contains a 
   - `/navigation`- Routes - wire up the router with any & all screens. [Read More &rarr;](/src/navigation/README.md)
   - `/redux` - Redux Reducers & Actions grouped by type. [Read More &rarr;](/src/redux/README.md)
   - `/theme` - Theme specific styles and variables
-
-
-

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,6 +2,10 @@
 
 Run `npm test` to run a test add `-- --watch` to run it in developer mode.
 
+To run an individual Jest test:
+* Run `jest path/to/test.js` if you have Jest installed globally
+* Run `node_modules/.bin/jest path/to/test.js` to use the projects Jest installation
+
 Tests should be placed in their related parents folder to keep consistency, i.e __components/\_\_tests\_\___ or __containers/\_\_tests\_\___
 
 - (Snapshot testing) https://facebook.github.io/jest/docs/tutorial-react-native.html#snapshot-test

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,4 +1,4 @@
-/* global jest */
+/* global jest fetch */
 
 jest.mock('Linking', () =>
   ({
@@ -9,3 +9,20 @@ jest.mock('Linking', () =>
     getInitialURL: jest.fn(),
   }),
 );
+
+// Mocking the global.fetch included in React Native
+global.fetch = jest.fn();
+
+// Helper to mock a success response (only once)
+fetch.mockResponseSuccess = (body) => {
+  fetch.mockImplementationOnce(
+    () => Promise.resolve({ json: () => Promise.resolve(JSON.parse(body)) }),
+  );
+};
+
+// Helper to mock a failure response (only once)
+fetch.mockResponseFailure = (error) => {
+  fetch.mockImplementationOnce(
+    () => Promise.reject(error),
+  );
+};

--- a/src/lib/__tests__/api-test.js
+++ b/src/lib/__tests__/api-test.js
@@ -1,0 +1,37 @@
+/**
+ * Test to check if the API is working as expected
+ */
+/* global it expect jest */
+import 'react-native';
+
+import AppAPI from '@lib/api';
+
+it('Has endpoints available', () => {
+  let numberOfEndpoints = 0;
+
+  Object.keys(AppAPI).forEach((endpoint) => {
+    numberOfEndpoints += 1;
+
+    expect(endpoint).not.toBe(undefined);
+  });
+
+  expect(numberOfEndpoints).not.toBe(0);
+});
+
+it('Has REST methods available', () => {
+  const excludedEndpoints = [
+    'handleError',
+    'getToken',
+    'deleteToken',
+  ];
+
+  Object.keys(AppAPI).forEach((endpoint) => {
+    if (excludedEndpoints.indexOf(endpoint) > -1) return;
+
+    expect(typeof AppAPI[endpoint].get).toEqual('function');
+    expect(typeof AppAPI[endpoint].post).toEqual('function');
+    expect(typeof AppAPI[endpoint].patch).toEqual('function');
+    expect(typeof AppAPI[endpoint].put).toEqual('function');
+    expect(typeof AppAPI[endpoint].delete).toEqual('function');
+  });
+});

--- a/src/redux/__tests__/recipes/reducer.test.js
+++ b/src/redux/__tests__/recipes/reducer.test.js
@@ -1,0 +1,15 @@
+/**
+ * Test to check if a reducer is working as expected
+ */
+/* global it expect jest */
+import 'react-native';
+
+import recipeReducer, { initialState } from '@redux/recipes/reducer';
+import { getMeals } from '@redux/recipes/actions';
+
+it('Updates the state of recipes', () => {
+  expect(recipeReducer(initialState, getMeals())).toEqual({
+    ...initialState,
+    meals: [],
+  });
+});

--- a/src/redux/__tests__/router/reducer.test.js
+++ b/src/redux/__tests__/router/reducer.test.js
@@ -1,0 +1,15 @@
+/**
+ * Test to check if a reducer is working as expected
+ */
+/* global it expect jest */
+import 'react-native';
+
+import routerReducer, { initialState } from '@redux/router/reducer';
+import { ActionConst } from 'react-native-router-flux';
+
+it('Updates the state of the router', () => {
+  expect(routerReducer(initialState, ActionConst)).toEqual({
+    ...initialState,
+    scene: {},
+  });
+});

--- a/src/redux/__tests__/sidemenu/action.test.js
+++ b/src/redux/__tests__/sidemenu/action.test.js
@@ -1,0 +1,25 @@
+/**
+ * Test to check if an action is working as expected
+ */
+/* global it expect jest */
+import 'react-native';
+
+import * as sideMenuActions from '@redux/sidemenu/actions';
+
+it('Creates a SIDEMENU_TOGGLE action', () => {
+  expect(sideMenuActions.toggle()).toEqual({
+    type: 'SIDEMENU_TOGGLE',
+  });
+});
+
+it('Creates a SIDEMENU_OPEN action', () => {
+  expect(sideMenuActions.open()).toEqual({
+    type: 'SIDEMENU_OPEN',
+  });
+});
+
+it('Creates a SIDEMENU_CLOSE action', () => {
+  expect(sideMenuActions.close()).toEqual({
+    type: 'SIDEMENU_CLOSE',
+  });
+});

--- a/src/redux/__tests__/sidemenu/reducer.test.js
+++ b/src/redux/__tests__/sidemenu/reducer.test.js
@@ -1,0 +1,29 @@
+/**
+ * Test to check if a reducer is working as expected
+ */
+/* global it expect jest */
+import 'react-native';
+
+import sideMenuReducer, { initialState } from '@redux/sidemenu/reducer';
+import * as sideMenuActions from '@redux/sidemenu/actions';
+
+it('Updates the state of the side menu to toggle', () => {
+  expect(sideMenuReducer(initialState, sideMenuActions.toggle())).toEqual({
+    ...initialState,
+    isOpen: !initialState.isOpen,
+  });
+});
+
+it('Updates the state of the side menu to open', () => {
+  expect(sideMenuReducer(initialState, sideMenuActions.open())).toEqual({
+    ...initialState,
+    isOpen: true,
+  });
+});
+
+it('Updates the state of the side menu to close', () => {
+  expect(sideMenuReducer(initialState, sideMenuActions.close())).toEqual({
+    ...initialState,
+    isOpen: false,
+  });
+});

--- a/src/redux/__tests__/user/reducer.test.js
+++ b/src/redux/__tests__/user/reducer.test.js
@@ -1,0 +1,32 @@
+/**
+ * Test to check if a reducer is working as expected
+ */
+/* global it expect jest */
+import 'react-native';
+
+import userReducer, { initialState } from '@redux/user/reducer';
+import * as userActions from '@redux/user/actions';
+
+it('Updates the state of the user on login', () => {
+  expect(userReducer(initialState, userActions.login())).toEqual({
+    ...initialState,
+  });
+});
+
+it('Updates the state of the user on logout', () => {
+  expect(userReducer(initialState, userActions.logout())).toEqual({
+    ...initialState,
+  });
+});
+
+it('Updates the state of the user on retrieval', () => {
+  expect(userReducer(initialState, userActions.getMe())).toEqual({
+    ...initialState,
+  });
+});
+
+it('Updates the state of the user on update', () => {
+  expect(userReducer(initialState, userActions.updateMe())).toEqual({
+    ...initialState,
+  });
+});

--- a/src/redux/recipes/reducer.js
+++ b/src/redux/recipes/reducer.js
@@ -8,7 +8,7 @@
 import AppUtil from '@lib/util';
 
 // Set initial state
-const initialState = {
+export const initialState = {
   meals: [],
 };
 

--- a/src/redux/sidemenu/reducer.js
+++ b/src/redux/sidemenu/reducer.js
@@ -6,7 +6,7 @@
  */
 
 // Set initial state
-const initialState = {
+export const initialState = {
   isOpen: false,
   disableGestures: false,
 };


### PR DESCRIPTION
This pull request implements Jest tests for most of the Redux store and basic usage of the API class.

Some actions haven't been implemented due to tight coupling of their functionality with the API and relying on deeply mocked responses should be avoided; I suggest we de-couple Redux from the API by moving API requests out of Redux and into the components themselves.

The API tests are not trivial and simply test for the creation of endpoints and their REST functionality, mock tests for API requests/responses are once again a lot harder to implement as the API class itself is tightly coupled with other methods - these should be separated as much as possible.

We do however have the ability to implement a global .fetch() override (which Jest suggests) which I've included as a part of this pull request; this can be used to mock responses once we de-couple the API class a bit more.

edit: Also added badges to README