### PR TITLE
Allow named params in API routes

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -128,7 +128,16 @@ function fetcher(method, endpoint, params, body) {
     if (params) {
       // Object - eg. /recipes?title=this&cat=2
       if (typeof params === 'object') {
-        // If there's an 'id' prop, /{id}?
+
+        // Replace matching params in API routes eg. /recipes/{param}/foo
+        for (let param in params) {
+          if (endpoint.includes(`{${param}}`)) {
+            endpoint = endpoint.split(`{${param}}`).join(params[param]);
+            delete params[param];
+          }
+        }
+
+        // Check if there's still an 'id' prop, /{id}?
         if (params.id !== undefined) {
           if (typeof params.id === 'string' || typeof params.id === 'number') {
             urlParams = `/${params.id}`;
@@ -136,7 +145,7 @@ function fetcher(method, endpoint, params, body) {
           }
         }
 
-        // The rest of the params
+        // Add the rest of the params as a query string
         urlParams = `?${serialize(params)}`;
 
       // String or Number - eg. /recipes/23


### PR DESCRIPTION
I have API routes that don't have an ID at the end so I've created a way to add named params in routes.

For example in contants/api.js, 

```
['recipes_favourite', 'recipes/{id}/favourite']`
```

And to use it

```
AppAPI.recipes_favourite.get({id: 33});
```

You can also have API endpoints with multiple params:

```
['user_recipe', 'users/{userId}/recipes/{recipeId}']
```

```
AppAPI.user_recipe.get({userId: 33, recipeId: 2});
```