### PR TITLE
Add props 'type' for tabicon

### DIFF
--- a/src/components/ui/TabIcon.js
+++ b/src/components/ui/TabIcon.js
@@ -25,7 +25,7 @@ const TabIcon = ({ icon, selected, type }) => (
 TabIcon.propTypes = {
   icon: PropTypes.string.isRequired,
   selected: PropTypes.bool,
-  type: PropTypes.string
+  type: PropTypes.string,
 };
 TabIcon.defaultProps = { icon: 'search', selected: false, type: null };
 

--- a/src/components/ui/TabIcon.js
+++ b/src/components/ui/TabIcon.js
@@ -22,7 +22,11 @@ const TabIcon = ({ icon, selected, type }) => (
   />
 );
 
-TabIcon.propTypes = { icon: PropTypes.string.isRequired, selected: PropTypes.bool, type: PropTypes.string };
+TabIcon.propTypes = {
+  icon: PropTypes.string.isRequired,
+  selected: PropTypes.bool,
+  type: PropTypes.string
+};
 TabIcon.defaultProps = { icon: 'search', selected: false, type: null };
 
 /* Export Component ==================================================================== */

--- a/src/components/ui/TabIcon.js
+++ b/src/components/ui/TabIcon.js
@@ -13,16 +13,17 @@ import { Icon } from 'react-native-elements';
 import { AppColors } from '@theme/';
 
 /* Component ==================================================================== */
-const TabIcon = ({ icon, selected }) => (
+const TabIcon = ({ icon, selected, type }) => (
   <Icon
+    type={type}
     name={icon}
     size={26}
     color={selected ? AppColors.tabbar.iconSelected : AppColors.tabbar.iconDefault}
   />
 );
 
-TabIcon.propTypes = { icon: PropTypes.string.isRequired, selected: PropTypes.bool };
-TabIcon.defaultProps = { icon: 'search', selected: false };
+TabIcon.propTypes = { icon: PropTypes.string.isRequired, selected: PropTypes.bool, type: PropTypes.string };
+TabIcon.defaultProps = { icon: 'search', selected: false, type: null };
 
 /* Export Component ==================================================================== */
 export default TabIcon;


### PR DESCRIPTION
Add propTypes is 'type' for TabIcon component. We can use more icon font

<img width="367" alt="screen shot 2017-09-18 at 10 18 45 am" src="https://user-images.githubusercontent.com/2627147/30528215-03fd83ae-9c5b-11e7-8295-8214ae379d42.png">
<img width="621" alt="screen shot 2017-09-18 at 10 18 19 am" src="https://user-images.githubusercontent.com/2627147/30528216-03feddc6-9c5b-11e7-9922-e0d196198b0b.png">

