### PR TITLE
Proper removal of react-native-device-info

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,7 +135,6 @@ android {
 dependencies {
     compile project(':react-native-vector-icons')
     compile project(':react-native-google-analytics-bridge')
-    compile project(':react-native-device-info')
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"  // From node_modules

--- a/android/app/src/main/java/com/starterkit/MainApplication.java
+++ b/android/app/src/main/java/com/starterkit/MainApplication.java
@@ -6,7 +6,6 @@ import android.util.Log;
 import com.facebook.react.ReactApplication;
 import com.oblador.vectoricons.VectorIconsPackage;
 import com.idehub.GoogleAnalyticsBridge.GoogleAnalyticsBridgePackage;
-import com.learnium.RNDeviceInfo.RNDeviceInfo;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
@@ -29,8 +28,7 @@ public class MainApplication extends Application implements ReactApplication {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
             new VectorIconsPackage(),
-            new GoogleAnalyticsBridgePackage(),
-            new RNDeviceInfo()
+            new GoogleAnalyticsBridgePackage()
       );
     }
   };


### PR DESCRIPTION
References to this module had to be removed from build.gradle and MainApplication.java so that the app will successfully build on Android.