### PR TITLE
Needs Expo CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ The project is _super_ helpful to kick-start your next project, as it provides a
 
 ## 🚀 Getting Started
 
+#### 0. Prerequisites
+Make sure you have Expo CLI installed
+```bash
+npm install -g expo-cli
+```
+
 #### 1. Clone and Install
 
 _*It's recommended that you install [React Native Debugger](https://github.com/jhen0409/react-native-debugger/releases) and open before `yarn start`._


### PR DESCRIPTION
Suggest updating the Readme to include the prerequisite of having Expo CLI installed first. I'm not sure how that's self-explanatory, then again I'm not a professional React or RN programmer, so I might have missed something obvious.